### PR TITLE
Adding support for hexadecimal, flip, ascii, pow and sqrt

### DIFF
--- a/five.js
+++ b/five.js
@@ -24,7 +24,6 @@
   five.piglatin = function() { return 'ivefay' };
   five.italian = function() { return 'cinque' };
   five.spanish = function() { return 'cinco' };
-
   five.morseCode = function() { return 'di-di-di-di-dit' };
   five.binary = function() { return '101'; };
   five.octal = function() { return '5'; };

--- a/five.js
+++ b/five.js
@@ -25,7 +25,6 @@
   five.italian = function() { return 'cinque' };
   five.spanish = function() { return 'cinco' };
 
-
   five.morseCode = function() { return 'di-di-di-di-dit' };
   five.binary = function() { return '101'; };
   five.octal = function() { return '5'; };
@@ -36,6 +35,9 @@
   five.smooth = function() { return "S"; }
   five.flip = function() { return 'ϛ'; };
   five.ascii = function() { return ' _____\n| ____|\n| |__\n|___ \\\n ___) | \n|____/'; };
+
+  five.sqrt = function() { return Math.sqrt(5); };
+  five.pow = function(n) { n = typeof n === 'undefined' ? 2 : n; return Math.pow(5, n); };
 
   five.tooSlow = function() {
     var returnIn = new Date(new Date().valueOf() + 555);

--- a/five.js
+++ b/five.js
@@ -29,11 +29,14 @@
   five.morseCode = function() { return 'di-di-di-di-dit' };
   five.binary = function() { return '101'; };
   five.octal = function() { return '5'; };
-  
+  five.hexadecimal = function() { return '0x5'; };
+
   five.negative = function() { return -5; }
   five.loud = function() { return "FIVE"; }
   five.smooth = function() { return "S"; }
-  
+  five.flip = function() { return 'ϛ'; };
+  five.ascii = function() { return ' _____\n| ____|\n| |__\n|___ \\\n ___) | \n|____/'; };
+
   five.tooSlow = function() {
     var returnIn = new Date(new Date().valueOf() + 555);
 

--- a/test.js
+++ b/test.js
@@ -33,6 +33,9 @@ assert.equal('5', five.octal(), 'An octal five should be 5');
 assert.equal('0x5', five.hexadecimal(), 'A hexadecimal five should be 0x5');
 assert.equal('ϛ', five.flip(), 'A flip five should be ϛ');
 assert.equal(' _____\n| ____|\n| |__\n|___ \\\n ___) | \n|____/', five.ascii(), 'A ascii five should be\n _____\n| ____|\n| |__\n|___ \\\n ___) | \n|____/');
+assert.equal(25, five.pow(), 'Five to the power of 2 should be 25');
+assert.equal(125, five.pow(3), 'Five to the power of 3 should be 125');
+assert.equal(2.23606797749979, five.sqrt(), 'A square root of five should be 2.23606797749979');
 
 assert.equal('-5', five.negative(), 'A negative five should be -5');
 assert.equal('FIVE', five.loud(), 'A loud five should be FIVE');

--- a/test.js
+++ b/test.js
@@ -30,6 +30,9 @@ assert.equal('cinco', five.spanish(), 'A spanish five should be cinco');
 assert.equal('di-di-di-di-dit', five.morseCode(), 'A five in morse code should be di-di-di-di-dit');
 assert.equal('101', five.binary(), 'A binary five should be 101');
 assert.equal('5', five.octal(), 'An octal five should be 5');
+assert.equal('0x5', five.hexadecimal(), 'A hexadecimal five should be 0x5');
+assert.equal('ϛ', five.flip(), 'A flip five should be ϛ');
+assert.equal(' _____\n| ____|\n| |__\n|___ \\\n ___) | \n|____/', five.ascii(), 'A ascii five should be\n _____\n| ____|\n| |__\n|___ \\\n ___) | \n|____/');
 
 assert.equal('-5', five.negative(), 'A negative five should be -5');
 assert.equal('FIVE', five.loud(), 'A loud five should be FIVE');


### PR DESCRIPTION
I've added brand new functionality for the five.
Now you can:
- get five in hexadecimal
- flip five
- get ascii version of five

I've made more commits, than I wanted, because I was fixing improper commit message. Sorry for that.