### PR TITLE
Overcomplicate five a bit more

### DIFF
--- a/five.js
+++ b/five.js
@@ -1,6 +1,6 @@
 (function () {
 
-  var five = function() { return 5; };
+  var five = function() { return !+[]+!![]+!![]+!![]+!![]; };
 
   five.upHigh = function() { return '⁵'; };
   five.downLow = function() { return '₅'; };


### PR DESCRIPTION
I always thought you should never use numbers directly like used in the five() function. This pull request solves that problem partly(555 is still used in the tooSlow function)
