### PR TITLE
"operator overloading"

### DIFF
--- a/five.js
+++ b/five.js
@@ -87,6 +87,8 @@
     return word.replace(/[a-zA-Z0-9]/g, replaceLetter);
   };
 
+  five.valueOf = function() { return 5 };
+
   if(typeof module !== 'undefined' && module.exports) {
     module.exports = five;
   } else if (window) {

--- a/test.js
+++ b/test.js
@@ -76,4 +76,10 @@ assert.equal('fghijklmnopqrstuvwxyzabcde', five.rot('abcdefghijklmnopqrstuvwxyz'
 assert.equal('FGHIJKLMNOPQRSTUVWXYZABCDE', five.rot('ABCDEFGHIJKLMNOPQRSTUVWXYZ'), 'Capital letters too');
 assert.equal('$_$ -,- @.@?', five.rot('$_$ -,- @.@?'), 'Emoticons should not be rotated');
 
+assert.equal(five * five, 25);
+assert.equal(five + five, 10);
+assert.equal(five / five, 1);
+assert.equal(five - five, 0);
+assert.equal((five / five) * (five), five);
+
 process.exit(0);


### PR DESCRIPTION
If you're doing maths with `five`, typing out all these brackets:

```
var result = five() * five() * five();
```

...is kind of tedious.

In the math context, we can assume you don't want the i18n/l10n or any of the other secondary features this module provides.

This reduces math-related friction so you can do `five * five`, `five + five / five - five` and so on. Maths-related use cases should now be a lot easier!
