### PR TITLE
Asynchronous version of tooSlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ five() / five(); // 1
 five.upHigh() // ⁵
 five.downLow() // ₅
 five.tooSlow() // 5, with a ~500 millisecond delay
+five.tooSlowAsync(Function callback) // non-blocking version of tooSlow
 five.roman() // V
 five.morseCode() // di-di-di-di-dit
 five.negative() // -5

--- a/five.js
+++ b/five.js
@@ -82,6 +82,12 @@
     return five();
   };
 
+  five.tooSlowAsync = function(callback) {
+    if(typeof(callback) === 'function'){
+      setTimeout(callback, 555, five());
+    }
+  };
+
   five.map = function(array) { return array.map(five); };
   five.reduce = function(array) { return array.reduce(five); };
 

--- a/test.js
+++ b/test.js
@@ -75,6 +75,15 @@ var finishes = new Date().valueOf();
 assert.equal(5, slowFive, 'A too slow five should still be five');
 assert.ok((finishes - now) > 500, 'A too slow five should take longer than 500 milliseconds to be returned, blocking execution and generally being a bad idea');
 
+var now = new Date().valueOf();
+var slowFive = five.tooSlowAsync(function(number){
+  var finishes = new Date().valueOf();
+  assert.ok((finishes - now) > 500, 'A too slow five should take longer than 500 milliseconds to be returned and be returned inside a callback');
+  assert.equal(5, number, 'A too slow five should still be five');
+});
+var after = new Date().valueOf();
+assert.ok((after - now) < 500, 'An asyncronous too slow five should not block execution');
+
 assert.equal(JSON.stringify(['Juwan Howard','Ray Jackson','Jimmy King','Jalen Rose','Chris Webber']), JSON.stringify(five.fab()), 'A fab five should be the 1991-1993 Michigan Mens Basketball Team');
 
 assert.equal(JSON.stringify([5, 5, 5]), JSON.stringify(five.map([1, 2, 3])));

--- a/test.js
+++ b/test.js
@@ -82,7 +82,7 @@ var slowFive = five.tooSlowAsync(function(number){
   assert.equal(5, number, 'A too slow five should still be five');
 });
 var after = new Date().valueOf();
-assert.ok((after - now) < 500, 'An asyncronous too slow five should not block execution');
+assert.ok((after - now) < 500, 'An asynchronous too slow five should not block execution');
 
 assert.equal(JSON.stringify(['Juwan Howard','Ray Jackson','Jimmy King','Jalen Rose','Chris Webber']), JSON.stringify(five.fab()), 'A fab five should be the 1991-1993 Michigan Mens Basketball Team');
 


### PR DESCRIPTION
The current implementation of `five.tooSlow()` blocks execution, which [as noted](../blob/master/test.js#L76) is

> generally a bad idea.

Included is a new method, `tooSlowAsync`, which takes in a callback to be executed after the too slow function completes. 