### PR TITLE
Make travis more complicated for marginally faster builds!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ script:
   - istanbul cover test.js
 after_script:
   - cat coverage/lcov.info | codeclimate
+
+sudo: false


### PR DESCRIPTION
The testing infrastructure is far too simple, so we __must__ upgrade to use Travis's Docker-container-based CI.