### PR TITLE
Added five.isFiveOrGreater() function for comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ five.hex(); // 5
 five.isFive(10); // false
 ```
 
+##### Comparison
+```javascript
+five.isFiveOrGreater(10); // true
+```
+
 ##### Filter, Map and Reduce
 ```javascript
 five.filter([5, true, 5]); // [5, 5]

--- a/five.js
+++ b/five.js
@@ -93,6 +93,8 @@
 
   five.isFive = function(a) { return a === five(); };
 
+  five.isFiveOrGreater = function(a) { return a >= five(); };
+
   five.map = function(array) { return array.map(five); };
   five.filter = function(array) { return array.filter(five.isFive); };
   five.reduce = function(array) { return array.reduce(five); };

--- a/test.js
+++ b/test.js
@@ -96,6 +96,10 @@ assert.equal(JSON.stringify(['Juwan Howard','Ray Jackson','Jimmy King','Jalen Ro
 assert.equal(true, five.isFive(five()));
 assert.equal(false, five.isFive(10));
 
+assert.equal(false, five.isFiveOrGreater(five() - five()));
+assert.equal(true, five.isFiveOrGreater(five()));
+assert.equal(true, five.isFiveOrGreater(five() + five()));
+
 assert.equal(JSON.stringify([5, 5]), JSON.stringify(five.filter([5, true, 5])));
 assert.equal(JSON.stringify([5, 5, 5]), JSON.stringify(five.map([1, 2, 3])));
 assert.equal(5, five.reduce([1, 2, 3]));


### PR DESCRIPTION
In honor of Microsoft deprecating `GetVersion` and replacing it with `IsWindows8Point1OrGreater` etc. I present this patch to also allow a similar pattern for comparison with five. No need to deprecate `five()` function yet though.