### PR TITLE
fixing README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ five.dothraki() // mek
 five.dovah() // hen
 five.dutch() // vijf
 five.elvish() // lempe
-five.english() // Five
+five.english() // five
 five.estonian() // viis
 five.finnish() // viisi
 five.french() // cinq


### PR DESCRIPTION
Hello. I noticed that the `README.md` file mentions that `five.english()` returns `Five` while it actually returns `five`, so I fixed it for you.