### PR TITLE
Added the members, singles and discography of 5ive

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ five.reduce([1, 2, 3]); // 5
 five.fab(); // ['Juwan Howard','Ray Jackson','Jimmy King','Jalen Rose','Chris Webber']
 five.jackson(); // ['Jackie','Tito','Jermaine','Marlon','Michael']
 five.luniz(); // ‘I Got 5 on It’
+five.members(); //['Sean Conlon', 'Ritchie Neville', 'Scott Robinson', 'Jason \'J\' Brown', 'Abz Love']
+five.discography(); //['5ive', 'Invincible', 'Kingsize']
+five.singles(); //['Slam Dunk (Da Funk)', 'When the Lights Go Out', 'Got the Feelin\'', 'Everybody Get Up', 'It\'s the Things You Do', 'Until the Time Is Through', 'If Ya Gettin\' Down', 'Keep On Movin\'', 'Don\'t Wanna Let You Go', 'We Will Rock You', 'Let\'s Dance', 'Closer to Me', 'Rock the Party', 'I Wish It Could Be Christmas Everyday']
+
+
 ```
 
 ##### Rotation

--- a/five.js
+++ b/five.js
@@ -106,6 +106,18 @@
     return ['Jackie','Tito','Jermaine','Marlon','Michael'];
   };
 
+  five.members = function() {
+    return ['Sean Conlon', 'Ritchie Neville', 'Scott Robinson', 'Jason \'J\' Brown', 'Abz Love'];
+  };
+
+  five.discography = function() {
+    return ['5ive', 'Invincible', 'Kingsize'];
+  };
+
+  five.singles = function() {
+    return ['Slam Dunk (Da Funk)', 'When the Lights Go Out', 'Got the Feelin\'', 'Everybody Get Up', 'It\'s the Things You Do', 'Until the Time Is Through', 'If Ya Gettin\' Down', 'Keep On Movin\'', 'Don\'t Wanna Let You Go', 'We Will Rock You', 'Let\'s Dance', 'Closer to Me', 'Rock the Party', 'I Wish It Could Be Christmas Everyday'];
+  }
+
   /**
    * References "I got 5 on it" by Luniz.
    * http://en.wikipedia.org/wiki/I_Got_5_on_It

--- a/test.js
+++ b/test.js
@@ -95,6 +95,13 @@ assert.equal(JSON.stringify(['Jackie','Tito','Jermaine','Marlon','Michael']), JS
 
 assert.equal(JSON.stringify(['Juwan Howard','Ray Jackson','Jimmy King','Jalen Rose','Chris Webber']), JSON.stringify(five.fab()), 'A fab five should be the 1991-1993 Michigan Mens Basketball Team');
 
+assert.equal(JSON.stringify(['Sean Conlon', 'Ritchie Neville', 'Scott Robinson', 'Jason \'J\' Brown', 'Abz Love']), JSON.stringify(five.members()), 'A five five should be the 90\'s boy band 5ive');
+
+assert.equal(JSON.stringify(['5ive', 'Invincible', 'Kingsize']), JSON.stringify(five.discography()), 'A five discography should be the studio albums released by the 90\'s boy band 5ive');
+
+assert.equal(JSON.stringify(['Slam Dunk (Da Funk)', 'When the Lights Go Out', 'Got the Feelin\'', 'Everybody Get Up', 'It\'s the Things You Do', 'Until the Time Is Through', 'If Ya Gettin\' Down', 'Keep On Movin\'', 'Don\'t Wanna Let You Go', 'We Will Rock You', 'Let\'s Dance', 'Closer to Me', 'Rock the Party', 'I Wish It Could Be Christmas Everyday']), JSON.stringify(five.singles()), 'A five singles should be the singles released by the 90\'s boy band 5ive');
+
+
 assert.equal(five.luniz(), 'I Got 5 on It', 'A Luniz five should be the song title of their most famous hit');
 
 assert.equal(true, five.isFive(five()));


### PR DESCRIPTION
Does not solve the issue as discussed at #10 as it does not play music by 5ive. Can be added if needed. Was thinking five.play() which executes `exec('open "https://www.youtube.com/watch?v=qoPRDbC85NE"');` on Mac and prints the link on other platforms?
