### PR TITLE
Add support for languages using Aegean numerals (Linear A, Linear B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ five.mdFive() // 30056e1cab7a61d256fc8edd970d14f5
 
 ##### 5 goes multilingual
 ```javascript
+five.aegean() // 𐄋
 five.arabic() // خمسة
 five.azerbaijani() // beş
 five.basque() // bost

--- a/five.js
+++ b/five.js
@@ -21,6 +21,7 @@
     return anotherNumber;
   };
 
+  five.aegean = function() { return '𐄋'; };
   five.arabic = function() { return 'خمسة'; };
   five.azerbaijani = function() { return 'beş'; };
   five.basque = function() { return 'bost'; };

--- a/test.js
+++ b/test.js
@@ -15,6 +15,7 @@ assert.equal('₅', five.downLow(), 'A down low five should be a subscripted 5')
 assert.equal('V', five.roman(), 'A roman five should be a V');
 
 
+assert.equal('𐄋', five.aegean(), 'An aegean five should be 𐄋');
 assert.equal('خمسة', five.arabic(), 'A arabic five should be خمسة');
 assert.equal('beş', five.azerbaijani(), 'A azerbaijani five should be beş');
 assert.equal('bost', five.basque(), 'A basque five should be bost');


### PR DESCRIPTION
These are a great omission for historians using the library, so I thought I might add them.