### PR TITLE
Improve Polish interoperability

### DIFF
--- a/five.js
+++ b/five.js
@@ -69,7 +69,7 @@
   five.norwegian = function() { return 'fem'; };
   five.persian = function() { return 'پنج'; };
   five.piglatin = function() { return 'ivefay'; };
-  five.polish = function() { return 'pięć'; };
+  five.polish = function() { return 'piątka'; };
   five.portuguese = function () { return 'cinco'; };
   five.punjabi = function () { return 'ਪੰਜ'; };
   five.romanian = function() { return 'cinci'; };


### PR DESCRIPTION
"pięć" translates to "five" and "five of something"

"piątka" translates to "the number five", "high five" and "consisting of five elements", which works better in the context of The Law of Fives