### PR TITLE
Support both major elvish dialects

### DIFF
--- a/five.js
+++ b/five.js
@@ -41,7 +41,12 @@
   five.dothraki = function() { return 'mek'; };
   five.dovah = function() { return 'hen'; };
   five.dutch = function() { return 'vijf'; };
-  five.elvish = function() { return 'lempe'; };
+  five.elvish = function() {
+    console.warn('"elvish" is deprecated for imprecision - call "quenya" or "sindarin" instead; returning Quenya for backward compatibility');
+    return five.quenya();
+  };
+  five.quenya = function() { return 'lempë'; };
+  five.sindarin = function() { return 'leben'; };
   five.english = function() { return 'five'; };
   five.esperanto = function() { return 'kvin'; };
   five.estonian = function() { return 'viis'; };

--- a/test.js
+++ b/test.js
@@ -31,7 +31,26 @@ assert.equal('pět', five.czech(), 'A czech five should be pět');
 assert.equal('mek', five.dothraki(), 'A dothraki five should be mek');
 assert.equal('hen', five.dovah(), 'A dovah five should be hen');
 assert.equal('vijf', five.dutch(), 'A dutch five should be vijf');
-assert.equal('lempe', five.elvish(), 'A elvish five should be lempe');
+assert.equal('lempë', five.elvish(), 'An elvish five should be Quenya');
+(function() {
+  var realWarn = console.warn.bind(console);
+  var called = false;
+  var calledWith = null;
+  console.warn = function(arg) {
+    called = true;
+    calledWith = arg;
+  };
+
+  five.elvish();
+  assert.equal(called, true,
+               'An elvish five should warn');
+  assert.notEqual(calledWith.match(/deprecated/), null,
+                  'An elvish five should be deprecated');
+  
+  console.warn = realWarn;
+})();
+assert.equal('lempë', five.quenya(), 'A Quenya five should be Quenya');
+assert.equal('leben', five.sindarin(), 'A Sindarin five should be Quenya');
 assert.equal('five', five.english(), 'A english five should be five');
 assert.equal('kvin', five.esperanto(), 'An esperanto five should be kvin');
 assert.equal('viis', five.estonian(), 'An estonian five should be viis');


### PR DESCRIPTION
"Elvish" is insufficiently precise; the major dialects in Tolkien's
legendarium are Quenya, the old speech of the High Elves, and Sindarin,
the common tongue at the time of the Fellowship. It is very important
that this distinction be correctly represented here. A deprecation
warning has been added for "elvish"; however, in this version it
continues to return the Quenya form, itself corrected to include diacritics.