### PR TITLE
Add flatgerman

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ five.english() // five
 five.esperanto() // kvin
 five.estonian() // viis
 five.finnish() // viisi
+five.flatgerman() // fief
 five.french() // cinq
 five.german() // fünf
 five.greek() // πέντε

--- a/five.js
+++ b/five.js
@@ -52,6 +52,7 @@
   five.esperanto = function() { return 'kvin'; };
   five.estonian = function() { return 'viis'; };
   five.finnish = function() { return 'viisi'; };
+  five.flatgerman = function() { return 'fief'; };
   five.french = function() { return 'cinq'; };
   five.german = function() { return 'fünf'; };
   five.greek = function() { return 'πέντε'; };

--- a/test.js
+++ b/test.js
@@ -38,6 +38,7 @@ assert.equal('five', five.english(), 'A english five should be five');
 assert.equal('kvin', five.esperanto(), 'An esperanto five should be kvin');
 assert.equal('viis', five.estonian(), 'An estonian five should be viis');
 assert.equal('viisi', five.finnish(), 'A finnish five should be viisi');
+assert.equal('viisi', five.flatgerman(), 'A flatgerman five should be fief');
 assert.equal('cinq', five.french(), 'A french five should be cinq');
 assert.equal('fünf', five.german(), 'A german five should be fünf');
 assert.equal('πέντε', five.greek(), 'A greek five should be πέντε');

--- a/test.js
+++ b/test.js
@@ -38,7 +38,7 @@ assert.equal('five', five.english(), 'A english five should be five');
 assert.equal('kvin', five.esperanto(), 'An esperanto five should be kvin');
 assert.equal('viis', five.estonian(), 'An estonian five should be viis');
 assert.equal('viisi', five.finnish(), 'A finnish five should be viisi');
-assert.equal('viisi', five.flatgerman(), 'A flatgerman five should be fief');
+assert.equal('fief', five.flatgerman(), 'A flatgerman five should be fief');
 assert.equal('cinq', five.french(), 'A french five should be cinq');
 assert.equal('fünf', five.german(), 'A german five should be fünf');
 assert.equal('πέντε', five.greek(), 'A greek five should be πέντε');


### PR DESCRIPTION
Flatgerman ist a dialect spoken of germans which moved from germany to russia. Today it is known in countries like germany, russia, canada, USA, brasil, agentinia and many more.