### PR TITLE
Add Danish and Faroese

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ five.elvish('quenya') // lempë
 five.elvish('sindarin') // leben
 five.english() // five
 five.esperanto() // kvin
+five.faroese() // fimm
 five.estonian() // viis
 five.finnish() // viisi
 five.french() // cinq

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ five.chinese('financial') // 伍
 five.choctaw() // tahlapi
 five.croatian() // pet
 five.czech() // pět
+five.danish() // fem
 five.dothraki() // mek
 five.dovah() // hen
 five.dutch() // vijf

--- a/five.js
+++ b/five.js
@@ -38,6 +38,7 @@
   five.choctaw = function() { return 'tahlapi'; };
   five.croatian = function() { return 'pet'; };
   five.czech = function() { return 'pět'; };
+  five.danish = function() { return 'fem'; };
   five.dothraki = function() { return 'mek'; };
   five.dovah = function() { return 'hen'; };
   five.dutch = function() { return 'vijf'; };

--- a/five.js
+++ b/five.js
@@ -52,6 +52,7 @@
   five.english = function() { return 'five'; };
   five.esperanto = function() { return 'kvin'; };
   five.estonian = function() { return 'viis'; };
+  five.faroese = function() { return 'fimm'; };
   five.finnish = function() { return 'viisi'; };
   five.french = function() { return 'cinq'; };
   five.german = function() { return 'fünf'; };

--- a/test.js
+++ b/test.js
@@ -28,6 +28,7 @@ assert.equal('伍', five.chinese('financial'), 'A chinese five in financial cont
 assert.equal('tahlapi', five.choctaw(), 'A choctaw five should be tahlapi');
 assert.equal('pet', five.croatian(), 'A croatian five should be pet');
 assert.equal('pět', five.czech(), 'A czech five should be pět');
+assert.equal('fem', five.danish(), 'A danish five should be fem');
 assert.equal('mek', five.dothraki(), 'A dothraki five should be mek');
 assert.equal('hen', five.dovah(), 'A dovah five should be hen');
 assert.equal('vijf', five.dutch(), 'A dutch five should be vijf');

--- a/test.js
+++ b/test.js
@@ -38,6 +38,7 @@ assert.equal('leben', five.elvish('sindarin'), 'An elvish five in Sindarin shoul
 assert.equal('five', five.english(), 'A english five should be five');
 assert.equal('kvin', five.esperanto(), 'An esperanto five should be kvin');
 assert.equal('viis', five.estonian(), 'An estonian five should be viis');
+assert.equal('fimm', five.faroese(), 'A faroese five should be fimm');
 assert.equal('viisi', five.finnish(), 'A finnish five should be viisi');
 assert.equal('cinq', five.french(), 'A french five should be cinq');
 assert.equal('fünf', five.german(), 'A german five should be fünf');


### PR DESCRIPTION
It is very important that all FIVE Nordic (Germanic) languages are available (Danish, Faroese, Icelandic, Norwegian and Swedish).