### PR TITLE
Include five.atomic()

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ five.mdFive() // 30056e1cab7a61d256fc8edd970d14f5
 five.golden() // 1.618033988749895
 ```
 
+##### Scientific
+```javascript
+five.atomic(); // 'Boron'
+```
+
 ##### 5 goes multilingual
 ```javascript
 five.arabic() // خمسة

--- a/five.js
+++ b/five.js
@@ -109,6 +109,8 @@
     // returns 5*4*3*2*1 optimized at 500% normal factorial runtime;
     return 120;
   }
+  
+  five.atomic = function() { return 'Boron'; };
 
   five.negative = function() { return -five(); };
   five.loud = function (lang) { return (lang && typeof five[lang] === 'function') ? five[lang]().toUpperCase() : five.english().toUpperCase();};

--- a/test.js
+++ b/test.js
@@ -88,6 +88,8 @@ assert.equal('5', five.hex(), 'An hexadecimal five should be 5');
 assert.equal('30056e1cab7a61d256fc8edd970d14f5', five.mdFive(), 'md5 checksum of "five" should be 30056e1cab7a61d256fc8edd970d14f5');
 assert.equal('1.618033988749895', five.golden(), 'A golden five is Phive');
 
+assert.equal('Boron', five.atomic(), 'An atomic five should be boron');
+
 assert.equal('-5', five.negative(), 'A negative five should be -5');
 assert.equal('FIVE', five.loud(), 'A loud five should be FIVE');
 assert.equal('IVEFAY', five.loud('piglatin'), 'A loud five in Pig Latin should be IVEFAY');

--- a/test.js
+++ b/test.js
@@ -88,7 +88,7 @@ assert.equal('5', five.hex(), 'An hexadecimal five should be 5');
 assert.equal('30056e1cab7a61d256fc8edd970d14f5', five.mdFive(), 'md5 checksum of "five" should be 30056e1cab7a61d256fc8edd970d14f5');
 assert.equal('1.618033988749895', five.golden(), 'A golden five is Phive');
 
-assert.equal('Boron', five.atomic(), 'An atomic five should be boron');
+assert.equal('Boron', five.atomic(), 'An atomic five should be Boron');
 
 assert.equal('-5', five.negative(), 'A negative five should be -5');
 assert.equal('FIVE', five.loud(), 'A loud five should be FIVE');


### PR DESCRIPTION
This pull requests adds five.atomic(). It outputs Boron, the element with an atomic number of 5, and the 5th element on the periodic table. It includes tests and is documented in the README. I decided to capitalize the output. I also couldn't find an appropriate place for scientific fives, and this felt out of place under novel, so I created a Scientific section in the README.