### PR TITLE
💙 Galizian Language 💙

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ five.esperanto() // kvin
 five.estonian() // viis
 five.finnish() // viisi
 five.french() // cinq
+five.galician() // cinco
 five.german() // fünf
 five.greek() // πέντε
 five.hebrew() // חמש

--- a/five.js
+++ b/five.js
@@ -53,6 +53,7 @@
   five.estonian = function() { return 'viis'; };
   five.finnish = function() { return 'viisi'; };
   five.french = function() { return 'cinq'; };
+  five.galician = function() { return 'cinco' };
   five.german = function() { return 'fünf'; };
   five.greek = function() { return 'πέντε'; };
   five.hebrew = function() { return 'חמש'; };
@@ -108,7 +109,7 @@
   five.factorial = function() {
     // returns 5*4*3*2*1 optimized at 500% normal factorial runtime;
     return 120;
-  }
+  };
 
   five.negative = function() { return -five(); };
   five.loud = function (lang) { return (lang && typeof five[lang] === 'function') ? five[lang]().toUpperCase() : five.english().toUpperCase();};

--- a/test.js
+++ b/test.js
@@ -39,6 +39,7 @@ assert.equal('kvin', five.esperanto(), 'An esperanto five should be kvin');
 assert.equal('viis', five.estonian(), 'An estonian five should be viis');
 assert.equal('viisi', five.finnish(), 'A finnish five should be viisi');
 assert.equal('cinq', five.french(), 'A french five should be cinq');
+assert.equal('cinco', five.galician(), 'A galician five should be cinco');
 assert.equal('fünf', five.german(), 'A german five should be fünf');
 assert.equal('πέντε', five.greek(), 'A greek five should be πέντε');
 assert.equal('חמש', five.hebrew(), 'A hebrew five should be חמש');


### PR DESCRIPTION
`five` is translated into Spanish, Catalan, Basque, Portuguese...

It is still necessary to translate it into Galician so that `five`
can be used throughout the Iberian Peninsula!

But do not spread panic, now `five` is translated into Galician!

```js
console.log( five.galician() );
// >>> cinco
```