### PR TITLE
Added the Tengwar unicode character for five

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ five.dutch() // vijf
 five.elvish() // lempë
 five.elvish('quenya') // lempë
 five.elvish('sindarin') // leben
+five.elvish('tengwar') //  (not supported by most fonts, use Code2001 for example)
 five.english() // five
 five.esperanto() // kvin
 five.estonian() // viis

--- a/five.js
+++ b/five.js
@@ -45,6 +45,7 @@
     switch(type) {
       case 'quenya': return 'lempë';
       case 'sindarin': return 'leben';
+      case 'tengwar': return '\ue065';
       default: return 'lempë';
     }
   };

--- a/test.js
+++ b/test.js
@@ -34,6 +34,7 @@ assert.equal('vijf', five.dutch(), 'A dutch five should be vijf');
 assert.equal('lempë', five.elvish(), 'An elvish five should be lempë');
 assert.equal('lempë', five.elvish('quenya'), 'An elvish five in Quenya should be lempë');
 assert.equal('leben', five.elvish('sindarin'), 'An elvish five in Sindarin should be leben');
+assert.equal('', five.elvish('tengwar'), 'A five in tengwar should be the corresponding unicode character');
 assert.equal('five', five.english(), 'A english five should be five');
 assert.equal('kvin', five.esperanto(), 'An esperanto five should be kvin');
 assert.equal('viis', five.estonian(), 'An estonian five should be viis');


### PR DESCRIPTION
`five` currently is not inclusive to elves that can't read the roman alphabet.