### PR TITLE
Derive 5 from language syntax

### DIFF
--- a/five.js
+++ b/five.js
@@ -1,6 +1,7 @@
 (function () {
 
-  var five = function() { return 5; };
+  // derive 5 from first principles (language syntax)
+  var five = function() { return --((typeof []).length); };
 
   // Quote: Malaclypse the Younger, Principia Discordia, Page 00016
   five.law = function() { return 'The Law of Fives states simply that: All things happen in fives, or are divisible by or are multiples of five, or are somehow directly or indirectly appropriate to 5. The Law of Fives is never wrong.'; };


### PR DESCRIPTION
Instead of relying on a predefined value of `5`, it can be derived from first principles (e.g. low level language syntax).
This also makes the assertion in `test.js` more meaningful since it now doesn't just assert literal values to be equal.