### PR TITLE
README overcomplicate -> simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # five.js
 
-A library to overcomplicate `5`.
+A library to simplify `5`.
 
 [![Build Status](https://travis-ci.org/jackdcrawford/five.svg?branch=master)](https://travis-ci.org/jackdcrawford/five)
 [![Code Climate](https://codeclimate.com/github/jackdcrawford/five.png)](https://codeclimate.com/github/jackdcrawford/five)


### PR DESCRIPTION
we all know getting a `5` in javascript requires a lot of effort, `five` simplifies the progress by calling a single function, I don't understand why `README.md` says it "overcomplicates", is it a typo?