### PR TITLE
Add in Fijian, Maori and Urdu languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ five.elvish('sindarin') // leben
 five.english() // five
 five.esperanto() // kvin
 five.estonian() // viis
+five.fijian() // lima
 five.finnish() // viisi
 five.french() // cinq
 five.german() // fünf
@@ -111,6 +112,7 @@ five.latin() // quinque
 five.latvian() // pieci
 five.lithuanian() // penki
 five.maltese() // ħamsa
+five.maori() // rima
 five.mongolian() // таван
 five.nepali() // पाँच
 five.norwegian() // fem
@@ -131,6 +133,7 @@ five.tamil() // ஐந்து
 five.telugu() // ఐదు
 five.thai() // ห้า
 five.turkish() // beş
+five.urdu() // پاںچ
 five.ukrainian() // п’ять
 five.welsh() // pump
 ```

--- a/five.js
+++ b/five.js
@@ -51,6 +51,7 @@
   five.english = function() { return 'five'; };
   five.esperanto = function() { return 'kvin'; };
   five.estonian = function() { return 'viis'; };
+  five.fijian = function() { return 'lima'; };
   five.finnish = function() { return 'viisi'; };
   five.french = function() { return 'cinq'; };
   five.german = function() { return 'fünf'; };
@@ -70,6 +71,7 @@
   five.latvian = function() { return 'pieci'; };
   five.lithuanian = function() { return 'penki'; };
   five.maltese = function() { return 'ħamsa'; };
+  five.maori = function() { return 'rima'; };
   five.mongolian = function() { return 'таван'; };
   five.nepali = function() { return 'पाँच'; };
   five.norwegian = function() { return 'fem'; };
@@ -90,6 +92,7 @@
   five.telugu = function() { return 'ఐదు'; };
   five.turkish = function() { return 'beş'; };
   five.thai = function() { return 'ห้า'; };
+  five.urdu = function() { return 'پاںچ'; };
   five.ukrainian = function() { return 'п’ять'; };
   five.welsh = function() { return 'pump'; };
 

--- a/test.js
+++ b/test.js
@@ -37,6 +37,7 @@ assert.equal('leben', five.elvish('sindarin'), 'An elvish five in Sindarin shoul
 assert.equal('five', five.english(), 'A english five should be five');
 assert.equal('kvin', five.esperanto(), 'An esperanto five should be kvin');
 assert.equal('viis', five.estonian(), 'An estonian five should be viis');
+assert.equal('lima', five.fijian(), 'A fijian five should be lima');
 assert.equal('viisi', five.finnish(), 'A finnish five should be viisi');
 assert.equal('cinq', five.french(), 'A french five should be cinq');
 assert.equal('fünf', five.german(), 'A german five should be fünf');
@@ -55,6 +56,7 @@ assert.equal('오', five.korean(), 'A korean five should be 오');
 assert.equal('quinque', five.latin(), 'A latin five should be quinque');
 assert.equal('pieci', five.latvian(), 'A latvian five should be pieci');
 assert.equal('penki', five.lithuanian(), 'A lithuanian five should be penki');
+assert.equal('rima', five.maori(), 'A maori five should be rima');
 assert.equal('ħamsa', five.maltese(), ' A maltese five should be ħamsa');
 assert.equal('таван', five.mongolian(), 'A mongolian five should be таван');
 assert.equal('पाँच', five.nepali(), 'A nepali five should be पाँच');
@@ -76,6 +78,7 @@ assert.equal('ஐந்து', five.tamil(), 'A tamil five should be ஐந்�
 assert.equal('ఐదు', five.telugu(), 'A telugu five should be ఐదు');
 assert.equal('ห้า', five.thai(), 'A thai five should be ห้า');
 assert.equal('beş', five.turkish(), 'A turkish five should be beş');
+assert.equal('پاںچ', five.urdu(), 'An urdu five should be پاںچ');
 assert.equal('п’ять', five.ukrainian(), 'A ukrainian five should be п’ять');
 
 assert.equal('.....', five.morseCode(), 'A five in morse code should be .....');


### PR DESCRIPTION
Adding in the above 3 languages for 5.
Sources:
Fijian: https://omniglot.com/language/numbers/fijian.htm
Maori: https://www.twinkl.co.nz/resource/nz-n-009-numbers-1-20-cards-te-reo-maori
Urdu: https://www.ucl.ac.uk/atlas/urdu/alphabet2.html